### PR TITLE
Correcting the default version numbers for a number of messages that …

### DIFF
--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -37,6 +37,7 @@ SET(OpenIGTLink_SOURCES
   igtlutil/igtl_position.c
   igtlutil/igtl_capability.c
   igtlClientSocket.cxx
+  igtlCapabilityMessage.cxx
   igtlConditionVariable.cxx
   igtlFastMutexLock.cxx
   igtlImageMessage.cxx
@@ -71,6 +72,7 @@ SET(OpenIGTLink_INCLUDE_FILES
   igtlutil/igtl_win32header.h
   igtlMessageHandler.h
   igtlMessageHandlerMacro.h
+  igtlCapabilityMessage.h
   igtlClientSocket.h
   igtlConditionVariable.h
   igtlCreateObjectFunction.h
@@ -122,7 +124,6 @@ IF (${OpenIGTLink_PROTOCOL_VERSION} GREATER "1" )
     igtlutil/igtl_qtrans.c
     igtlutil/igtl_polydata.c
     igtlColorTableMessage.cxx
-    igtlCapabilityMessage.cxx
     igtlImageMetaMessage.cxx
     igtlLabelMetaMessage.cxx
     igtlPointMessage.cxx
@@ -153,7 +154,6 @@ IF (${OpenIGTLink_PROTOCOL_VERSION} GREATER "1" )
     igtlutil/igtl_qtrans.h
     igtlutil/igtl_polydata.h
     igtlColorTableMessage.h
-    igtlCapabilityMessage.h
     igtlImageMetaMessage.h
     igtlLabelMetaMessage.h
     igtlPointMessage.h

--- a/Source/igtlBindMessage.cxx
+++ b/Source/igtlBindMessage.cxx
@@ -36,6 +36,7 @@ BindMessageBase::~BindMessageBase()
 
 void BindMessageBase::Init()
 {
+  this->m_Version = 2;
   this->m_ChildMessages.clear();
 }
 

--- a/Source/igtlCapabilityMessage.cxx
+++ b/Source/igtlCapabilityMessage.cxx
@@ -45,27 +45,6 @@ CapabilityMessage::~CapabilityMessage()
   this->m_TypeNames.clear();
 }
 
-
-//void CapabilityMessage::SetTypes(int ntypes, const char names[][IGTL_HEADER_TYPE_SIZE])
-//{
-//  this->m_TypeNames.clear();
-//
-//  for(int i = 0; i < ntypes; i++)
-//    {
-//    std::string buf;
-//    if (strnlen(names[i], IGTL_HEADER_TYPE_SIZE) < IGTL_HEADER_TYPE_SIZE)
-//      {
-//      buf.append(names[i]);
-//      }
-//    else
-//      {
-//      buf.append(names[i], IGTL_HEADER_TYPE_SIZE);
-//      }
-//    this->m_TypeNames.push_back(buf);
-//    }
-//}
-
-
 void CapabilityMessage::SetTypes(std::vector<std::string> types)
 {
   this->m_TypeNames.clear();

--- a/Source/igtlCapabilityMessage.h
+++ b/Source/igtlCapabilityMessage.h
@@ -25,32 +25,10 @@
 namespace igtl
 {
 
-class IGTLCommon_EXPORT GetCapabilityMessage: public MessageBase
-{
-public:
-  typedef GetCapabilityMessage            Self;
-  typedef MessageBase                    Superclass;
-  typedef SmartPointer<Self>             Pointer;
-  typedef SmartPointer<const Self>       ConstPointer;
-
-  igtlTypeMacro(igtl::GetCapabilityMessage, igtl::MessageBase);
-  igtlNewMacro(igtl::GetCapabilityMessage);
-
-protected:
-  GetCapabilityMessage() : MessageBase() { this->m_DefaultBodyType  = "GET_CAPABIL"; };
-  ~GetCapabilityMessage() {};
-protected:
-  virtual int  GetBodyPackSize() { return 0; };
-  virtual int  PackBody()        { AllocatePack(); return 1; };
-  virtual int  UnpackBody()      { return 1; };
-};
-
-
 class IGTLCommon_EXPORT CapabilityMessage: public MessageBase
 {
 
 public:
-
   typedef CapabilityMessage          Self;
   typedef MessageBase                Superclass;
   typedef SmartPointer<Self>         Pointer;
@@ -60,15 +38,13 @@ public:
   igtlNewMacro(igtl::CapabilityMessage);
 
 public:
-  //void    SetTypes(int ntypes, const char names[][IGTL_HEADER_TYPE_SIZE]);
-  void    SetTypes(std::vector<std::string> types);
-  int     SetType(int id, const char* name);
-  const char* GetType(int id);
+  void                      SetTypes(std::vector<std::string> types);
+  int                       SetType(int id, const char* name);
+  const char*               GetType(int id);
   
-  void     SetNumberOfTypes(int n) { m_TypeNames.resize(n); }
-  int     GetNumberOfTypes() { return m_TypeNames.size(); }
-  //char**  GetTypeNames() { return m_TypeNames; }
-  std::vector<std::string> GetTypes() { return m_TypeNames; }
+  void                      SetNumberOfTypes(int n) { m_TypeNames.resize(n); }
+  int                       GetNumberOfTypes() { return m_TypeNames.size(); }
+  std::vector<std::string>  GetTypes() { return m_TypeNames; }
 
 protected:
   CapabilityMessage();

--- a/Source/igtlImageMetaMessage.cxx
+++ b/Source/igtlImageMetaMessage.cxx
@@ -190,7 +190,7 @@ igtlUint8 ImageMetaElement::GetScalarType()
 // igtl::ImageMetaMessage class
 
 ImageMetaMessage::ImageMetaMessage():
-  MessageBase()
+  ImageMetaMessageBase()
 {
   this->m_DefaultBodyType = "IMGMETA";
   this->m_ImageMetaList.clear();

--- a/Source/igtlImageMetaMessage.h
+++ b/Source/igtlImageMetaMessage.h
@@ -28,6 +28,23 @@
 namespace igtl
 {
 
+/// A base class for the GET_IMGMETA message types.
+class IGTLCommon_EXPORT ImageMetaMessageBase : public MessageBase
+{
+public:
+  typedef ImageMetaMessageBase           Self;
+  typedef MessageBase                    Superclass;
+  typedef SmartPointer<Self>             Pointer;
+  typedef SmartPointer<const Self>       ConstPointer;
+
+  igtlTypeMacro(igtl::ImageMetaMessageBase, igtl::MessageBase);
+  igtlNewMacro(igtl::ImageMetaMessageBase);
+
+protected:
+  ImageMetaMessageBase() : MessageBase() { this->m_Version = 2; };
+  ~ImageMetaMessageBase() {};
+};
+
 /// A class to manage meta data of images.
 class IGTLCommon_EXPORT ImageMetaElement: public Object
 {
@@ -134,19 +151,19 @@ protected:
 
 
 /// A class for the GET_IMGMETA message type.
-class IGTLCommon_EXPORT GetImageMetaMessage: public MessageBase
+class IGTLCommon_EXPORT GetImageMetaMessage: public ImageMetaMessageBase
 {
 public:
   typedef GetImageMetaMessage            Self;
-  typedef MessageBase                    Superclass;
+  typedef ImageMetaMessageBase           Superclass;
   typedef SmartPointer<Self>             Pointer;
   typedef SmartPointer<const Self>       ConstPointer;
 
-  igtlTypeMacro(igtl::GetImageMetaMessage, igtl::MessageBase);
+  igtlTypeMacro(igtl::GetImageMetaMessage, igtl::ImageMetaMessageBase);
   igtlNewMacro(igtl::GetImageMetaMessage);
 
 protected:
-  GetImageMetaMessage() : MessageBase() { this->m_DefaultBodyType  = "GET_IMGMETA"; };
+  GetImageMetaMessage() : ImageMetaMessageBase() { this->m_DefaultBodyType  = "GET_IMGMETA"; };
   ~GetImageMetaMessage() {};
 protected:
   virtual int  GetBodyPackSize() { return 0; };
@@ -160,15 +177,15 @@ protected:
 /// modality etc. An IMGMETA message can contain meta data for multiple images.
 /// This message type may be used to obtain a list of images available in
 /// the remote system, such as image database or commercial image-guided surgery (IGS) system.
-class IGTLCommon_EXPORT ImageMetaMessage: public MessageBase
+class IGTLCommon_EXPORT ImageMetaMessage: public ImageMetaMessageBase
 {
 public:
   typedef ImageMetaMessage               Self;
-  typedef MessageBase                    Superclass;
+  typedef ImageMetaMessageBase           Superclass;
   typedef SmartPointer<Self>             Pointer;
   typedef SmartPointer<const Self>       ConstPointer;
 
-  igtlTypeMacro(igtl::ImageMetaMessage, igtl::MessageBase);
+  igtlTypeMacro(igtl::ImageMetaMessage, igtl::ImageMetaMessageBase);
   igtlNewMacro(igtl::ImageMetaMessage);
 
 public:

--- a/Source/igtlLabelMetaMessage.cxx
+++ b/Source/igtlLabelMetaMessage.cxx
@@ -168,7 +168,7 @@ int LabelMetaElement::SetOwner(const char* owner)
 // igtl::LabelMetaMessage class
 
 LabelMetaMessage::LabelMetaMessage():
-  MessageBase()
+  LabelMetaMessageBase()
 {
   this->m_DefaultBodyType = "LBMETA";
   this->m_LabelMetaList.clear();

--- a/Source/igtlLabelMetaMessage.h
+++ b/Source/igtlLabelMetaMessage.h
@@ -28,6 +28,23 @@
 namespace igtl
 {
 
+/// A base class for the LBMETA message types.
+class IGTLCommon_EXPORT LabelMetaMessageBase : public MessageBase
+{
+public:
+  typedef LabelMetaMessageBase            Self;
+  typedef MessageBase                    Superclass;
+  typedef SmartPointer<Self>             Pointer;
+  typedef SmartPointer<const Self>       ConstPointer;
+
+  igtlTypeMacro(igtl::LabelMetaMessageBase, igtl::MessageBase);
+  igtlNewMacro(igtl::LabelMetaMessageBase);
+
+protected:
+  LabelMetaMessageBase() : MessageBase() { this->m_Version = 2; };
+  ~LabelMetaMessageBase(){};
+};
+
 class IGTLCommon_EXPORT LabelMetaElement: public Object
 {
 public:
@@ -120,19 +137,19 @@ protected:
 
 
 /// A class for the GET_LBMETA message type.
-class IGTLCommon_EXPORT GetLabelMetaMessage: public MessageBase
+class IGTLCommon_EXPORT GetLabelMetaMessage: public LabelMetaMessageBase
 {
 public:
   typedef GetLabelMetaMessage            Self;
-  typedef MessageBase                    Superclass;
+  typedef LabelMetaMessageBase           Superclass;
   typedef SmartPointer<Self>             Pointer;
   typedef SmartPointer<const Self>       ConstPointer;
 
-  igtlTypeMacro(igtl::GetLabelMetaMessage, igtl::MessageBase);
+  igtlTypeMacro(igtl::GetLabelMetaMessage, igtl::LabelMetaMessageBase);
   igtlNewMacro(igtl::GetLabelMetaMessage);
 
 protected:
-  GetLabelMetaMessage() : MessageBase() { this->m_DefaultBodyType  = "GET_LBMETA"; };
+  GetLabelMetaMessage() : LabelMetaMessageBase() { this->m_DefaultBodyType  = "GET_LBMETA"; };
   ~GetLabelMetaMessage() {};
 protected:
   virtual int  GetBodyPackSize() { return 0; };
@@ -144,15 +161,15 @@ protected:
 /// The LBMETA is used to transfer meta information for label maps, which are not available
 /// in the IMAGE message type. To retrieve voxel objects or a label map, GET_IMAGE / IMAGE
 /// can be used. But the client should be able to get a list of available structures.
-class IGTLCommon_EXPORT LabelMetaMessage: public MessageBase
+class IGTLCommon_EXPORT LabelMetaMessage: public LabelMetaMessageBase
 {
 public:
   typedef LabelMetaMessage               Self;
-  typedef MessageBase                    Superclass;
+  typedef LabelMetaMessageBase           Superclass;
   typedef SmartPointer<Self>             Pointer;
   typedef SmartPointer<const Self>       ConstPointer;
 
-  igtlTypeMacro(igtl::LabelMetaMessage, igtl::MessageBase);
+  igtlTypeMacro(igtl::LabelMetaMessage, igtl::LabelMetaMessageBase);
   igtlNewMacro(igtl::LabelMetaMessage);
 
 public:
@@ -189,6 +206,3 @@ protected:
 } // namespace igtl
 
 #endif // _igtlLabelMetaMessage_h
-
-
-

--- a/Source/igtlMessageFactory.cxx
+++ b/Source/igtlMessageFactory.cxx
@@ -54,6 +54,7 @@ namespace igtl
     this->AddMessageType("GET_IMAGE", (PointerToMessageBaseNew)&igtl::GetImageMessage::New);
     this->AddMessageType("STATUS", (PointerToMessageBaseNew)&igtl::StatusMessage::New);
     this->AddMessageType("GET_STATUS", (PointerToMessageBaseNew)&igtl::GetStatusMessage::New);
+    this->AddMessageType("CAPABILITY", (PointerToMessageBaseNew)&igtl::CapabilityMessage::New);
 #if OpenIGTLink_PROTOCOL_VERSION >= 2
     this->AddMessageType("POINT", (PointerToMessageBaseNew)&igtl::PointMessage::New);
     this->AddMessageType("GET_POINT", (PointerToMessageBaseNew)&igtl::GetPointMessage::New);
@@ -68,8 +69,6 @@ namespace igtl
     this->AddMessageType("RTS_QTDATA", (PointerToMessageBaseNew)&igtl::RTSQuaternionTrackingDataMessage::New);
     this->AddMessageType("STT_QTDATA", (PointerToMessageBaseNew)&igtl::StartQuaternionTrackingDataMessage::New);
     this->AddMessageType("STP_QTDATA", (PointerToMessageBaseNew)&igtl::StopQuaternionTrackingDataMessage::New);
-    this->AddMessageType("CAPABILITY", (PointerToMessageBaseNew)&igtl::CapabilityMessage::New);
-    this->AddMessageType("GET_CAPABIL", (PointerToMessageBaseNew)&igtl::GetCapabilityMessage::New);
 #endif //OpenIGTLink_PROTOCOL_VERSION >= 2
 #if OpenIGTLink_PROTOCOL_VERSION >= 3
     this->AddMessageType("COMMAND", (PointerToMessageBaseNew)&igtl::CommandMessage::New);

--- a/Source/igtlNDArrayMessage.cxx
+++ b/Source/igtlNDArrayMessage.cxx
@@ -142,6 +142,7 @@ NDArrayMessage::NDArrayMessage():
   MessageBase()
 {
   this->m_DefaultBodyType = "NDARRAY";
+  this->m_Version = 2;
   this->m_Array = NULL;
   this->m_Type = 0;
 }

--- a/Source/igtlPointMessage.cxx
+++ b/Source/igtlPointMessage.cxx
@@ -163,7 +163,7 @@ int PointElement::SetOwner(const char* owner)
 // igtl::PointMessage class
 
 PointMessage::PointMessage():
-  MessageBase()
+  PointMessageBase()
 {
   this->m_DefaultBodyType = "POINT";
   this->m_PointList.clear();

--- a/Source/igtlPointMessage.h
+++ b/Source/igtlPointMessage.h
@@ -116,21 +116,37 @@ protected:
   std::string   m_Owner; 
 };
 
-
-/// A class for the GET_POINT message type.
-class IGTLCommon_EXPORT GetPointMessage: public MessageBase
+/// A base class for the POINT message types.
+class IGTLCommon_EXPORT PointMessageBase : public MessageBase
 {
 public:
-  typedef GetPointMessage            Self;
+  typedef PointMessageBase               Self;
   typedef MessageBase                    Superclass;
   typedef SmartPointer<Self>             Pointer;
   typedef SmartPointer<const Self>       ConstPointer;
 
-  igtlTypeMacro(igtl::GetPointMessage, igtl::MessageBase);
+  igtlTypeMacro(igtl::PointMessageBase, igtl::MessageBase);
+  igtlNewMacro(igtl::PointMessageBase);
+
+protected:
+  PointMessageBase() : MessageBase() { this->m_Version = 2; };
+  ~PointMessageBase(){};
+};
+
+/// A class for the GET_POINT message type.
+class IGTLCommon_EXPORT GetPointMessage: public PointMessageBase
+{
+public:
+  typedef GetPointMessage                Self;
+  typedef PointMessageBase               Superclass;
+  typedef SmartPointer<Self>             Pointer;
+  typedef SmartPointer<const Self>       ConstPointer;
+
+  igtlTypeMacro(igtl::GetPointMessage, igtl::PointMessageBase);
   igtlNewMacro(igtl::GetPointMessage);
 
 protected:
-  GetPointMessage() : MessageBase() { this->m_DefaultBodyType  = "GET_POINT"; };
+  GetPointMessage() : PointMessageBase() { this->m_DefaultBodyType  = "GET_POINT"; };
   ~GetPointMessage() {};
 protected:
   virtual int  GetBodyPackSize() { return 0; };
@@ -141,15 +157,15 @@ protected:
 
 /// A class for the POINT message type.
 /// The POINT message type is designed to transfer information about fiducials, which are often used in surgical planning and navigation in the image-guided therapy.
-class IGTLCommon_EXPORT PointMessage: public MessageBase
+class IGTLCommon_EXPORT PointMessage: public PointMessageBase
 {
 public:
-  typedef PointMessage               Self;
-  typedef MessageBase                    Superclass;
+  typedef PointMessage                   Self;
+  typedef PointMessageBase               Superclass;
   typedef SmartPointer<Self>             Pointer;
   typedef SmartPointer<const Self>       ConstPointer;
 
-  igtlTypeMacro(igtl::PointMessage, igtl::MessageBase);
+  igtlTypeMacro(igtl::PointMessage, igtl::PointMessageBase);
   igtlNewMacro(igtl::PointMessage);
 
 public:
@@ -187,6 +203,3 @@ protected:
 } // namespace igtl
 
 #endif // _igtlPointMessage_h
-
-
-

--- a/Source/igtlPolyDataMessage.cxx
+++ b/Source/igtlPolyDataMessage.cxx
@@ -421,7 +421,7 @@ int PolyDataAttribute::GetNthData(unsigned int n, igtlFloat32 * data)
 // Description:
 // PolyDataMessage class implementation
 PolyDataMessage::PolyDataMessage():
-  MessageBase()
+  PolyDataMessageBase()
 {
   this->m_DefaultBodyType = "POLYDATA";
   Clear();
@@ -873,6 +873,16 @@ PolyDataAttribute * PolyDataMessage::GetAttribute(unsigned int id)
     }
 
   return this->m_Attributes[id];
+}
+
+GetPolyDataMessage::GetPolyDataMessage()
+{
+  this->m_DefaultBodyType  = "GET_POLYDATA";
+}
+
+PolyDataMessageBase::PolyDataMessageBase()
+{
+  this->m_Version = 2;
 }
 
 } // namespace igtl

--- a/Source/igtlPolyDataMessage.h
+++ b/Source/igtlPolyDataMessage.h
@@ -26,8 +26,25 @@
 namespace igtl
 {
 
+/// A base class for the POLYDATA message type.
+class IGTLCommon_EXPORT PolyDataMessageBase : public MessageBase
+{
+public:
+  typedef PolyDataMessageBase            Self;
+  typedef MessageBase                    Superclass;
+  typedef SmartPointer<Self>             Pointer;
+  typedef SmartPointer<const Self>       ConstPointer;
+
+  igtlTypeMacro(igtl::PolyDataMessageBase, igtl::MessageBase);
+  igtlNewMacro(igtl::PolyDataMessageBase);
+
+protected:
+  PolyDataMessageBase();
+  ~PolyDataMessageBase(){};
+};
+
 /// A class for the GET_POLYDATA message type.
-class IGTLCommon_EXPORT GetPolyDataMessage: public MessageBase
+class IGTLCommon_EXPORT GetPolyDataMessage: public PolyDataMessageBase
 {
 public:
   typedef GetPolyDataMessage            Self;
@@ -35,11 +52,11 @@ public:
   typedef SmartPointer<Self>             Pointer;
   typedef SmartPointer<const Self>       ConstPointer;
 
-  igtlTypeMacro(igtl::GetPolyDataMessage, igtl::MessageBase);
+  igtlTypeMacro(igtl::GetPolyDataMessage, igtl::PolyDataMessageBase);
   igtlNewMacro(igtl::GetPolyDataMessage);
 
 protected:
-  GetPolyDataMessage() : MessageBase() { this->m_DefaultBodyType  = "GET_POLYDATA"; };
+  GetPolyDataMessage();
   ~GetPolyDataMessage() {};
 protected:
   virtual int  GetBodyPackSize() { return 0; };
@@ -265,7 +282,7 @@ class IGTLCommon_EXPORT PolyDataAttribute : public Object {
 
 
 /// A class for the POLYDATA message type.
-class IGTLCommon_EXPORT PolyDataMessage: public MessageBase
+class IGTLCommon_EXPORT PolyDataMessage: public PolyDataMessageBase
 {
 public:
   typedef PolyDataMessage                Self;
@@ -273,7 +290,7 @@ public:
   typedef SmartPointer<Self>             Pointer;
   typedef SmartPointer<const Self>       ConstPointer;
 
-  igtlTypeMacro(igtl::PolyDataMessage, igtl::MessageBase);
+  igtlTypeMacro(igtl::PolyDataMessage, igtl::PolyDataMessageBase);
   igtlNewMacro(igtl::PolyDataMessage);
 
 public:
@@ -356,6 +373,3 @@ protected:
 } // namespace igtl
 
 #endif // _igtlPolyDataMessage_h
-
-
-

--- a/Source/igtlQuaternionTrackingDataMessage.cxx
+++ b/Source/igtlQuaternionTrackingDataMessage.cxx
@@ -153,8 +153,7 @@ void QuaternionTrackingDataElement::GetQuaternion(float* qx, float* qy, float* q
 //----------------------------------------------------------------------
 // igtl::StartQuaternionTrackingDataMessage class
 
-StartQuaternionTrackingDataMessage::StartQuaternionTrackingDataMessage():
-  MessageBase()
+StartQuaternionTrackingDataMessage::StartQuaternionTrackingDataMessage()
 {
   this->m_DefaultBodyType = "STT_QTDATA";
   this->m_Resolution      = 0;
@@ -222,6 +221,12 @@ int StartQuaternionTrackingDataMessage::UnpackBody()
 }
 
 
+RTSQuaternionTrackingDataMessage::RTSQuaternionTrackingDataMessage() 
+  : m_Status(0)
+{
+  this->m_DefaultBodyType  = "RTS_QTDATA";
+}
+
 //----------------------------------------------------------------------
 // igtl::RTSQuaternionTrackingDataMessage class
 
@@ -260,8 +265,7 @@ int  RTSQuaternionTrackingDataMessage::UnpackBody()
 //----------------------------------------------------------------------
 // igtl::QuaternionTrackingDataMessage class
 
-QuaternionTrackingDataMessage::QuaternionTrackingDataMessage():
-  MessageBase()
+QuaternionTrackingDataMessage::QuaternionTrackingDataMessage()
 {
   this->m_DefaultBodyType = "QTDATA";
   this->m_QuaternionTrackingDataList.clear();
@@ -390,9 +394,14 @@ int QuaternionTrackingDataMessage::UnpackBody()
   return 1;
 }
 
+QuaternionTrackingDataMessageBase::QuaternionTrackingDataMessageBase()
+{
+  this->m_Version = 2;
+}
+
+StopQuaternionTrackingDataMessage::StopQuaternionTrackingDataMessage()
+{
+  this->m_DefaultBodyType  = "STP_QTDATA";
+}
+
 } // namespace igtl
-
-
-
-
-

--- a/Source/igtlQuaternionTrackingDataMessage.h
+++ b/Source/igtlQuaternionTrackingDataMessage.h
@@ -109,18 +109,35 @@ protected:
   igtlFloat32   m_quaternion[4];
 };
 
-
-/// A class for the STT_QTDATA message type.
-class IGTLCommon_EXPORT StartQuaternionTrackingDataMessage: public MessageBase
+/// A base class for the QTDATA message type.
+class IGTLCommon_EXPORT QuaternionTrackingDataMessageBase: public MessageBase
 {
 
 public:
-  typedef StartQuaternionTrackingDataMessage  Self;
+  typedef QuaternionTrackingDataMessageBase   Self;
   typedef MessageBase                         Superclass;
   typedef SmartPointer<Self>                  Pointer;
   typedef SmartPointer<const Self>            ConstPointer;
 
-  igtlTypeMacro(igtl::StartQuaternionTrackingDataMessage, igtl::MessageBase);
+  igtlTypeMacro(igtl::QuaternionTrackingDataMessageBase, igtl::MessageBase);
+  igtlNewMacro(igtl::QuaternionTrackingDataMessageBase);
+
+protected:
+  QuaternionTrackingDataMessageBase();
+  ~QuaternionTrackingDataMessageBase(){};
+};
+
+/// A class for the STT_QTDATA message type.
+class IGTLCommon_EXPORT StartQuaternionTrackingDataMessage: public QuaternionTrackingDataMessageBase
+{
+
+public:
+  typedef StartQuaternionTrackingDataMessage  Self;
+  typedef QuaternionTrackingDataMessageBase   Superclass;
+  typedef SmartPointer<Self>                  Pointer;
+  typedef SmartPointer<const Self>            ConstPointer;
+
+  igtlTypeMacro(igtl::StartQuaternionTrackingDataMessage, igtl::QuaternionTrackingDataMessageBase);
   igtlNewMacro(igtl::StartQuaternionTrackingDataMessage);
 
 public:
@@ -157,19 +174,19 @@ protected:
 };
 
 
-class IGTLCommon_EXPORT StopQuaternionTrackingDataMessage: public MessageBase
+class IGTLCommon_EXPORT StopQuaternionTrackingDataMessage: public QuaternionTrackingDataMessageBase
 {
 public:
   typedef StopQuaternionTrackingDataMessage  Self;
-  typedef MessageBase                        Superclass;
+  typedef QuaternionTrackingDataMessageBase  Superclass;
   typedef SmartPointer<Self>                 Pointer;
   typedef SmartPointer<const Self>           ConstPointer;
 
-  igtlTypeMacro(igtl::StopQuaternionTrackingDataMessage, igtl::MessageBase);
+  igtlTypeMacro(igtl::StopQuaternionTrackingDataMessage, igtl::QuaternionTrackingDataMessageBase);
   igtlNewMacro(igtl::StopQuaternionTrackingDataMessage);
 
 protected:
-  StopQuaternionTrackingDataMessage() : MessageBase() { this->m_DefaultBodyType  = "STP_QTDATA"; };
+  StopQuaternionTrackingDataMessage();
   ~StopQuaternionTrackingDataMessage() {};
 
 protected:
@@ -181,11 +198,11 @@ protected:
 
 
 /// A class for the RTS_QTDATA message type.
-class IGTLCommon_EXPORT RTSQuaternionTrackingDataMessage: public MessageBase
+class IGTLCommon_EXPORT RTSQuaternionTrackingDataMessage: public QuaternionTrackingDataMessageBase
 {
 public:
   typedef RTSQuaternionTrackingDataMessage  Self;
-  typedef MessageBase                       Superclass;
+  typedef QuaternionTrackingDataMessageBase Superclass;
   typedef SmartPointer<Self>                Pointer;
   typedef SmartPointer<const Self>          ConstPointer;
 
@@ -195,7 +212,7 @@ public:
     STATUS_ERROR = 1
   };
 
-  igtlTypeMacro(igtl::RTSQuaternionTrackingDataMessage, igtl::MessageBase);
+  igtlTypeMacro(igtl::RTSQuaternionTrackingDataMessage, igtl::QuaternionTrackingDataMessageBase);
   igtlNewMacro(igtl::RTSQuaternionTrackingDataMessage);
 
   /// Sets the status. 'status' must be either STATUS_SUCCESS or STATUS_ERROR.
@@ -205,7 +222,7 @@ public:
   igtlUint8     GetStatus()                { return this->m_Status; };
 
 protected:
-  RTSQuaternionTrackingDataMessage() : MessageBase(), m_Status(0) { this->m_DefaultBodyType  = "RTS_QTDATA"; };
+  RTSQuaternionTrackingDataMessage();
   ~RTSQuaternionTrackingDataMessage() {};
 
   /// A variable to store the status.
@@ -222,15 +239,15 @@ protected:
 /// The QTDATA message type is intended for transferring 3D positions of surgical tools,
 /// markers etc. Its role is almost identical to TDATA, except that QTDATA describes
 /// orientation by using quaternion.
-class IGTLCommon_EXPORT QuaternionTrackingDataMessage: public MessageBase
+class IGTLCommon_EXPORT QuaternionTrackingDataMessage: public QuaternionTrackingDataMessageBase
 {
 public:
-  typedef QuaternionTrackingDataMessage  Self;
-  typedef MessageBase                    Superclass;
-  typedef SmartPointer<Self>             Pointer;
-  typedef SmartPointer<const Self>       ConstPointer;
+  typedef QuaternionTrackingDataMessage       Self;
+  typedef QuaternionTrackingDataMessageBase   Superclass;
+  typedef SmartPointer<Self>                  Pointer;
+  typedef SmartPointer<const Self>            ConstPointer;
 
-  igtlTypeMacro(igtl::QuaternionTrackingDataMessage, igtl::MessageBase);
+  igtlTypeMacro(igtl::QuaternionTrackingDataMessage, igtl::QuaternionTrackingDataMessageBase);
   igtlNewMacro(igtl::QuaternionTrackingDataMessage);
 
 public:
@@ -258,7 +275,7 @@ protected:
   virtual int  PackBody();
   virtual int  UnpackBody();
   
-  /// The list of trakcing data elements.
+  /// The list of tracking data elements.
   std::vector<QuaternionTrackingDataElement::Pointer> m_QuaternionTrackingDataList;
   
 };
@@ -267,6 +284,3 @@ protected:
 } // namespace igtl
 
 #endif // _igtlQuaternionTrackingDataMessage_h
-
-
-

--- a/Source/igtlSensorMessage.cxx
+++ b/Source/igtlSensorMessage.cxx
@@ -29,6 +29,7 @@ SensorMessage::SensorMessage():
 {
   m_DefaultBodyType  = "SENSOR";
 
+  this->m_Version = 2;
   this->m_Length = 0;
   this->m_Status = 0;
   this->m_Unit   = 0;

--- a/Source/igtlStringMessage.cxx
+++ b/Source/igtlStringMessage.cxx
@@ -28,6 +28,7 @@ StringMessage::StringMessage():
   MessageBase()
 {
   this->m_DefaultBodyType = "STRING";
+  this->m_Version = 2;
   this->m_Encoding = IGTL_STRING_MESSAGE_DEFAULT_ENCODING;
   this->m_String.clear();
 }

--- a/Source/igtlTrackingDataMessage.cxx
+++ b/Source/igtlTrackingDataMessage.cxx
@@ -158,7 +158,7 @@ void TrackingDataElement::GetMatrix(Matrix4x4& mat)
 // igtl::StartTrackingDataMessage class
 
 StartTrackingDataMessage::StartTrackingDataMessage():
-  MessageBase()
+  TrackingDataMessageBase()
 {
   this->m_DefaultBodyType = "STT_TDATA";
   this->m_Resolution      = 0;
@@ -265,7 +265,7 @@ int  RTSTrackingDataMessage::UnpackBody()
 // igtl::TrackingDataMessage class
 
 TrackingDataMessage::TrackingDataMessage():
-  MessageBase()
+  TrackingDataMessageBase()
 {
   this->m_DefaultBodyType = "TDATA";
   this->m_TrackingDataList.clear();
@@ -383,6 +383,11 @@ int TrackingDataMessage::UnpackBody()
     }
 
   return 1;
+}
+
+TrackingDataMessageBase::TrackingDataMessageBase()
+{
+  this->m_Version = 2;
 }
 
 } // namespace igtl

--- a/Source/igtlTrackingDataMessage.h
+++ b/Source/igtlTrackingDataMessage.h
@@ -27,6 +27,24 @@
 namespace igtl
 {
 
+/// A base class for the TDATA message types.
+class IGTLCommon_EXPORT TrackingDataMessageBase : public MessageBase
+{
+
+public:
+  typedef TrackingDataMessageBase        Self;
+  typedef MessageBase                    Superclass;
+  typedef SmartPointer<Self>             Pointer;
+  typedef SmartPointer<const Self>       ConstPointer;
+
+  igtlTypeMacro(igtl::TrackingDataMessageBase, igtl::MessageBase);
+  igtlNewMacro(igtl::TrackingDataMessageBase);
+
+protected:
+  TrackingDataMessageBase();
+  ~TrackingDataMessageBase(){};
+};
+
 class IGTLCommon_EXPORT TrackingDataElement: public Object
 {
 public:
@@ -100,16 +118,16 @@ protected:
 
 
 /// A class for the STT_TDATA message type.
-class IGTLCommon_EXPORT StartTrackingDataMessage: public MessageBase
+class IGTLCommon_EXPORT StartTrackingDataMessage: public TrackingDataMessageBase
 {
 
 public:
   typedef StartTrackingDataMessage       Self;
-  typedef MessageBase                    Superclass;
+  typedef TrackingDataMessageBase        Superclass;
   typedef SmartPointer<Self>             Pointer;
   typedef SmartPointer<const Self>       ConstPointer;
 
-  igtlTypeMacro(igtl::StartTrackingDataMessage, igtl::MessageBase);
+  igtlTypeMacro(igtl::StartTrackingDataMessage, igtl::TrackingDataMessageBase);
   igtlNewMacro(igtl::StartTrackingDataMessage);
 
 public:
@@ -146,19 +164,19 @@ protected:
 
 
 /// A class for the STP_TDATA message type.
-class IGTLCommon_EXPORT StopTrackingDataMessage: public MessageBase
+class IGTLCommon_EXPORT StopTrackingDataMessage: public TrackingDataMessageBase
 {
 public:
   typedef StopTrackingDataMessage        Self;
-  typedef MessageBase                    Superclass;
+  typedef TrackingDataMessageBase        Superclass;
   typedef SmartPointer<Self>             Pointer;
   typedef SmartPointer<const Self>       ConstPointer;
 
-  igtlTypeMacro(igtl::StopTrackingDataMessage, igtl::MessageBase);
+  igtlTypeMacro(igtl::StopTrackingDataMessage, igtl::TrackingDataMessageBase);
   igtlNewMacro(igtl::StopTrackingDataMessage);
 
 protected:
-  StopTrackingDataMessage() : MessageBase() { this->m_DefaultBodyType  = "STP_TDATA"; };
+  StopTrackingDataMessage() : TrackingDataMessageBase() { this->m_DefaultBodyType  = "STP_TDATA"; };
   ~StopTrackingDataMessage() {};
 
 protected:
@@ -170,11 +188,11 @@ protected:
 
 
 /// A class for the RTS_TDATA message type.
-class IGTLCommon_EXPORT RTSTrackingDataMessage: public MessageBase
+class IGTLCommon_EXPORT RTSTrackingDataMessage: public TrackingDataMessageBase
 {
 public:
   typedef RTSTrackingDataMessage         Self;
-  typedef MessageBase                    Superclass;
+  typedef TrackingDataMessageBase        Superclass;
   typedef SmartPointer<Self>             Pointer;
   typedef SmartPointer<const Self>       ConstPointer;
 
@@ -184,7 +202,7 @@ public:
     STATUS_ERROR = 1
   };
 
-  igtlTypeMacro(igtl::RTSTrackingDataMessage, igtl::MessageBase);
+  igtlTypeMacro(igtl::RTSTrackingDataMessage, igtl::TrackingDataMessageBase);
   igtlNewMacro(igtl::RTSTrackingDataMessage);
 
   /// Sets the status. 'status' must be either STATUS_SUCCESS or STATUS_ERROR.
@@ -194,7 +212,7 @@ public:
   igtlUint8     GetStatus()                { return this->m_Status; };
 
 protected:
-  RTSTrackingDataMessage() : MessageBase(), m_Status(0) { this->m_DefaultBodyType  = "RTS_TDATA"; };
+  RTSTrackingDataMessage() : TrackingDataMessageBase(), m_Status(0) { this->m_DefaultBodyType  = "RTS_TDATA"; };
   ~RTSTrackingDataMessage() {};
 
   /// A variable to store the status.
@@ -213,15 +231,15 @@ protected:
 /// type of 3D position sensor continuously and transferred as series of messages.
 /// Since it is important for software that receives TDATA to control data flow,
 /// STT_TDATA query data type has interval field to control the frame rate of consecutive messages.
-class IGTLCommon_EXPORT TrackingDataMessage: public MessageBase
+class IGTLCommon_EXPORT TrackingDataMessage: public TrackingDataMessageBase
 {
 public:
   typedef TrackingDataMessage            Self;
-  typedef MessageBase                    Superclass;
+  typedef TrackingDataMessageBase        Superclass;
   typedef SmartPointer<Self>             Pointer;
   typedef SmartPointer<const Self>       ConstPointer;
 
-  igtlTypeMacro(igtl::TrackingDataMessage, igtl::MessageBase);
+  igtlTypeMacro(igtl::TrackingDataMessage, igtl::TrackingDataMessageBase);
   igtlNewMacro(igtl::TrackingDataMessage);
 
 public:
@@ -251,7 +269,7 @@ protected:
   virtual int  PackBody();
   virtual int  UnpackBody();
 
-  /// The list of trakcing data elements.  
+  /// The list of tracking data elements.  
   std::vector<TrackingDataElement::Pointer> m_TrackingDataList;
   
 };
@@ -260,6 +278,3 @@ protected:
 } // namespace igtl
 
 #endif // _igtlTrackingDataMessage_h
-
-
-

--- a/Source/igtlTrajectoryMessage.cxx
+++ b/Source/igtlTrajectoryMessage.cxx
@@ -215,7 +215,7 @@ int TrajectoryElement::SetOwner(const char* owner)
 //----------------------------------------------------------------------
 // igtl::TrajectoryMessage class
 TrajectoryMessage::TrajectoryMessage():
-  MessageBase()
+  TrajectoryMessageBase()
 {
   this->m_DefaultBodyType = "TRAJ";
   this->m_TrajectoryList.clear();

--- a/Source/igtlTrajectoryMessage.h
+++ b/Source/igtlTrajectoryMessage.h
@@ -28,11 +28,28 @@
 namespace igtl
 {
 
+/// A base class for the TRAJ message types.
+class IGTLCommon_EXPORT TrajectoryMessageBase : public MessageBase
+{
+public:
+  typedef TrajectoryMessageBase          Self;
+  typedef MessageBase                    Superclass;
+  typedef SmartPointer<Self>             Pointer;
+  typedef SmartPointer<const Self>       ConstPointer;
+
+  igtlTypeMacro(igtl::TrajectoryMessageBase, igtl::MessageBase);
+  igtlNewMacro(igtl::TrajectoryMessageBase);
+
+protected:
+  TrajectoryMessageBase() : MessageBase() { this->m_Version = 2; };
+  ~TrajectoryMessageBase() {};
+};
+
 /// TrajectoryElement class is used to manage a trajectory in TrajectoryMessage class.
 class IGTLCommon_EXPORT TrajectoryElement: public Object
 {
 public:
-  typedef TrajectoryElement                   Self;
+  typedef TrajectoryElement              Self;
   typedef Object                         Superclass;
   typedef SmartPointer<Self>             Pointer;
   typedef SmartPointer<const Self>       ConstPointer;
@@ -147,19 +164,19 @@ protected:
 
 
 /// A class for the GET_TRAJ message type.
-class IGTLCommon_EXPORT GetTrajectoryMessage: public MessageBase
+class IGTLCommon_EXPORT GetTrajectoryMessage: public TrajectoryMessageBase
 {
 public:
-  typedef GetTrajectoryMessage            Self;
-  typedef MessageBase                    Superclass;
+  typedef GetTrajectoryMessage           Self;
+  typedef TrajectoryMessageBase          Superclass;
   typedef SmartPointer<Self>             Pointer;
   typedef SmartPointer<const Self>       ConstPointer;
 
-  igtlTypeMacro(igtl::GetTrajectoryMessage, igtl::MessageBase);
+  igtlTypeMacro(igtl::GetTrajectoryMessage, igtl::TrajectoryMessageBase);
   igtlNewMacro(igtl::GetTrajectoryMessage);
 
 protected:
-  GetTrajectoryMessage() : MessageBase() { this->m_DefaultBodyType  = "GET_TRAJ"; };
+  GetTrajectoryMessage() : TrajectoryMessageBase() { this->m_DefaultBodyType  = "GET_TRAJ"; };
   ~GetTrajectoryMessage() {};
 protected:
   virtual int  GetBodyPackSize() { return 0; };
@@ -170,15 +187,15 @@ protected:
 
 /// The TRAJECTORY message type support to transfer information about 3D trajectory,
 /// which is often used in surgical planning and guidance in image-guided therapy.
-class IGTLCommon_EXPORT TrajectoryMessage: public MessageBase
+class IGTLCommon_EXPORT TrajectoryMessage: public TrajectoryMessageBase
 {
 public:
-  typedef TrajectoryMessage               Self;
-  typedef MessageBase                    Superclass;
+  typedef TrajectoryMessage              Self;
+  typedef TrajectoryMessageBase          Superclass;
   typedef SmartPointer<Self>             Pointer;
   typedef SmartPointer<const Self>       ConstPointer;
 
-  igtlTypeMacro(igtl::TrajectoryMessage, igtl::MessageBase);
+  igtlTypeMacro(igtl::TrajectoryMessage, igtl::TrajectoryMessageBase);
   igtlNewMacro(igtl::TrajectoryMessage);
 
 public:
@@ -215,6 +232,3 @@ protected:
 } // namespace igtl
 
 #endif // _igtlTrajectoryMessage_h
-
-
-


### PR DESCRIPTION
…should have version 2 by default.

Added base classes to simplify future addition of RTS, STT, STP, and GET messages.

Moving capabilities to v1 section as per the specification.